### PR TITLE
enabled system76_acpi::kbd_backlight in leds

### DIFF
--- a/pkg/keyboard.go
+++ b/pkg/keyboard.go
@@ -25,7 +25,14 @@ var presetColors = map[string]RGBColor{
 	"white":  RGBColor{0, 0, 0},
 }
 
-var colorFiles = []string{"color_center", "color_left", "color_right", "color_extra"}
+var colorFiles = []string{"color", "color_center", "color_left", "color_right", "color_extra"}
+var ledClass = []string{"system76_acpi", "system76"}
+var sysFSPath =     "/sys/class/leds/%v::kbd_backlight"
+
+type SysPath struct {
+    Path  string
+    Files [8]string
+}
 
 // GetHex Converts a decimal number to hex representations
 func getHex(num int) string {
@@ -42,29 +49,59 @@ func (c RGBColor) GetColorInHex() string {
 	return hex
 }
 
+func getSysPath() SysPath {
+    ret := SysPath{"",[8]string{}}
+	for _, sub := range ledClass {
+		d := fmt.Sprintf(sysFSPath, sub)
+		if _, err := os.Stat(d); os.IsNotExist(err) != true {
+		    ret.Path = d
+		    break
+	    }
+	}
+	i := 0
+	for _, file := range colorFiles {
+		d := fmt.Sprintf("%v/%v", ret.Path, file)
+		if _, err := os.Stat(d); os.IsNotExist(err) != true {
+		    ret.Files[i] = file
+		    i += 1
+	    }
+	}
+	return ret
+}
+
 // ColorFileHandler writes a string to colorFiles
 func ColorFileHandler(c string) {
+    sys := getSysPath()
+    if sys.Path == "" {
+		log.Fatal("can't get a valid sysfs leds path")
+    }
 	_, exists := presetColors[c]
 	if exists {
 		c := presetColors[c]
 		color := c.GetColorInHex()
-		for _, file := range colorFiles {
-			p := fmt.Sprintf("/sys/class/leds/system76::kbd_backlight/%v", file)
+		for _, file := range sys.Files {
+		    if file == "" {
+		        continue
+		    }
+			p := fmt.Sprintf("%v/%v", sys.Path, file)
 			fh, err := os.OpenFile(p, os.O_RDWR, 0755)
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Print(err)
+				continue
 			}
 			fh.WriteString(color)
 			fh.Close()
 		}
 	} else {
-		for _, file := range colorFiles {
-			p := fmt.Sprintf("/sys/class/leds/system76::kbd_backlight/%v", file)
+		for _, file := range sys.Files {
+		    if file == "" {
+		        continue
+		    }
+			p := fmt.Sprintf("%v/%v", sys.Path, file)
 			fh, err := os.OpenFile(p, os.O_RDWR, 0755)
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Print(err)
+				continue
 			}
 			fh.WriteString(c)
 			fh.Close()
@@ -74,7 +111,9 @@ func ColorFileHandler(c string) {
 
 // BrightnessFileHandler writes a hex value to brightness, and returns the bytes written
 func BrightnessFileHandler(c string) int {
-	f, err := os.OpenFile("/sys/class/leds/system76::kbd_backlight/brightness", os.O_RDWR, 0755)
+    sys := getSysPath()
+    p := fmt.Sprintf("%v/brightness", sys.Path)
+	f, err := os.OpenFile(p, os.O_RDWR, 0755)
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
with darp6 there's only 1 color file and it's in
system76_acpi::kbd_backlight

created function to get all available colorFiles and the available
sysfs path.