### PR TITLE
Updated keyboard.go to have proper white value

### DIFF
--- a/pkg/keyboard.go
+++ b/pkg/keyboard.go
@@ -22,7 +22,7 @@ var presetColors = map[string]RGBColor{
 	"blue":   RGBColor{0, 0, 255},
 	"pink":   RGBColor{255, 105, 180},
 	"purple": RGBColor{128, 0, 128},
-	"white":  RGBColor{0, 0, 0},
+	"white":  RGBColor{255, 255, 255},
 }
 
 var colorFiles = []string{"color", "color_center", "color_left", "color_right", "color_extra"}


### PR DESCRIPTION
Changed white value from {0, 0, 0} to {255, 255, 255}